### PR TITLE
Disable view toggle button by default

### DIFF
--- a/packages/table-generator/package.json
+++ b/packages/table-generator/package.json
@@ -5,6 +5,7 @@
   "main": "dist/code.js",
   "scripts": {
     "test": "jest",
+    "test:watch": "jest --watch",
     "tsc": "npm run tsc:main && npm run tsc:ui && npm run tsc:tests",
     "tsc:main": "tsc --noEmit -p plugin-src",
     "tsc:ui": "tsc --noEmit -p ui-src",

--- a/packages/table-generator/ui-src/__tests__/view/ConfigView.spec.tsx
+++ b/packages/table-generator/ui-src/__tests__/view/ConfigView.spec.tsx
@@ -32,6 +32,36 @@ describe("ConfigView", () => {
       "true"
     );
   });
+  describe("view toggle button", () => {
+    test("is disabled by default", () => {
+      expect(
+        screen.getByRole("button", { name: "Configure Data" })
+      ).toHaveAttribute("aria-disabled", "true");
+    });
+    test("is available when valid grid is selected", () => {
+      renderResult?.rerender(
+        <ConfigView
+          setTableConfig={() => {}}
+          tableConfig={{
+            ...DEFAULT_TABLE_CONFIG,
+            headerCell: {
+              name: "Test header",
+              key: "abc",
+            },
+            bodyCell: {
+              name: "Test cell",
+              key: "def",
+            },
+          }}
+          validTableSelected={true}
+          initializing={false}
+        />
+      );
+      expect(
+        screen.getByRole("button", { name: "Configure Data" })
+      ).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
   test("sends create message to figma when clicking create", async () => {
     renderResult?.rerender(
       <ConfigView

--- a/packages/table-generator/ui-src/view/ConfigView.tsx
+++ b/packages/table-generator/ui-src/view/ConfigView.tsx
@@ -141,7 +141,7 @@ export const ConfigView = ({
         >
           <Button
             variant="primary"
-            disabled={!hasCellValuesSet}
+            disabled={!hasCellValuesSet || !validTableSelected}
             focusableWhenDisabled
             onClick={onToggleView}
           >


### PR DESCRIPTION
When plugin is first launched, it doesn't make sense for the user to toggle to the data view