### PR TITLE
Bump @figma/plugin-typings@^1.76.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "turbo": "latest"
       },
       "devDependencies": {
-        "@figma/plugin-typings": "^1.73.0",
+        "@figma/plugin-typings": "^1.76.0",
         "@figma/widget-typings": "^1.8.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
@@ -37,9 +37,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.1.0.tgz",
-      "integrity": "sha512-mMVJ/j/GbZ/De4ZHWbQAQO1J6iVnjtZLc9WEdkUQb8S/Bu2cAF2bETXUgMAdvMG3/ngtKmcNBe+Zms9bg6jnQQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
       "dev": true
     },
     "node_modules/@ampproject/remapping": {
@@ -991,9 +991,9 @@
       }
     },
     "node_modules/@figma/plugin-typings": {
-      "version": "1.73.0",
-      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.73.0.tgz",
-      "integrity": "sha512-wRZadOeniyy0uJNW/6K9kD1kjjKSW2xa6b/iMxrZSf66yS5EaPFPshQbl1Ug9gxBLWgIa5qtnjL0dbJ/JrlDoQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.76.0.tgz",
+      "integrity": "sha512-fGYPJJx9dIYf0X/ZaUjrNjhpmkv7XJzMj0C2GZjSje1wYfGWvddM07mXiS9NRQ+Ikrq0qim1bf6WZZmgL83ZEA==",
       "dev": true
     },
     "node_modules/@figma/widget-typings": {
@@ -6763,9 +6763,9 @@
   },
   "dependencies": {
     "@adobe/css-tools": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.1.0.tgz",
-      "integrity": "sha512-mMVJ/j/GbZ/De4ZHWbQAQO1J6iVnjtZLc9WEdkUQb8S/Bu2cAF2bETXUgMAdvMG3/ngtKmcNBe+Zms9bg6jnQQ==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
       "dev": true
     },
     "@ampproject/remapping": {
@@ -7374,9 +7374,9 @@
       "optional": true
     },
     "@figma/plugin-typings": {
-      "version": "1.73.0",
-      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.73.0.tgz",
-      "integrity": "sha512-wRZadOeniyy0uJNW/6K9kD1kjjKSW2xa6b/iMxrZSf66yS5EaPFPshQbl1Ug9gxBLWgIa5qtnjL0dbJ/JrlDoQ==",
+      "version": "1.76.0",
+      "resolved": "https://registry.npmjs.org/@figma/plugin-typings/-/plugin-typings-1.76.0.tgz",
+      "integrity": "sha512-fGYPJJx9dIYf0X/ZaUjrNjhpmkv7XJzMj0C2GZjSje1wYfGWvddM07mXiS9NRQ+Ikrq0qim1bf6WZZmgL83ZEA==",
       "dev": true
     },
     "@figma/widget-typings": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "turbo": "latest"
   },
   "devDependencies": {
-    "@figma/plugin-typings": "^1.73.0",
+    "@figma/plugin-typings": "^1.76.0",
     "@figma/widget-typings": "^1.8.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",


### PR DESCRIPTION
SuperScript is available through [openTypeFeatures](https://www.figma.com/plugin-docs/api/properties/TextNode-opentypefeatures/)