### PR TITLE
Use node 20 in GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 20
           cache: "npm"
       - name: Install dependencies
         run: npm i
@@ -24,7 +24,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 20
           cache: "npm"
       - name: Install dependencies
         run: npm i
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: 20
           cache: "npm"
       - name: Install dependencies
         run: npm i

--- a/packages/copy-manager/plugin-src/code.ts
+++ b/packages/copy-manager/plugin-src/code.ts
@@ -28,6 +28,7 @@ import {
   sendTextNodesInfoToUI,
   sortNodeByPosition,
 } from "./utils";
+import { scanTextNodesInfo } from "./processors/textNodeInfoProcessor";
 
 let parsedCsv: ParseResult<CsvNodeInfoWithLang> | null = null;
 

--- a/packages/copy-manager/plugin-src/code.ts
+++ b/packages/copy-manager/plugin-src/code.ts
@@ -28,7 +28,6 @@ import {
   sendTextNodesInfoToUI,
   sortNodeByPosition,
 } from "./utils";
-import { scanTextNodesInfo } from "./processors/textNodeInfoProcessor";
 
 let parsedCsv: ParseResult<CsvNodeInfoWithLang> | null = null;
 

--- a/packages/copy-manager/plugin-src/processors/csvProcessor.ts
+++ b/packages/copy-manager/plugin-src/processors/csvProcessor.ts
@@ -1,11 +1,13 @@
+import { parse } from "papaparse";
+import { convertToCsvDataUri } from "../../shared-src/export-utils";
 import {
   CsvNodeInfo,
   CsvNodeInfoWithProperId,
 } from "../../shared-src/messages";
 import {
   DEFAULT_HEADING_SETTINGS,
-  getHeadingLevelNumber,
   HeadingSettings,
+  getHeadingLevelNumber,
   loadAllFonts,
   replaceTextInTextNode,
   setRelaunchButton,
@@ -14,12 +16,10 @@ import {
 import {
   CsvExportSettings,
   CsvNodeInfoMap,
+  UpdaterSettings,
   iterate,
   iterateUpdate,
-  UpdaterSettings,
 } from "./iterate";
-import { unparse, parse } from "papaparse";
-import { convertToCsvDataUri } from "../../shared-src/export-utils";
 
 const getListOption = (node: TextNode): string => {
   const fullListOption = node.getRangeListOptions(0, node.characters.length);

--- a/packages/copy-manager/plugin-src/processors/iterate.ts
+++ b/packages/copy-manager/plugin-src/processors/iterate.ts
@@ -1,4 +1,4 @@
-import { CsvNodeInfoWithProperId } from "../../shared-src";
+import { CsvNodeInfoWithProperId } from "../../shared-src/messages";
 import { HeadingSettings, isChildrenMixin, isRectNodeImage } from "../utils";
 
 export type NodeProcessors<T> = {

--- a/packages/copy-manager/plugin-src/processors/textNodeInfoProcessor.ts
+++ b/packages/copy-manager/plugin-src/processors/textNodeInfoProcessor.ts
@@ -1,4 +1,4 @@
-import { SelectableTextNodeInfo } from "../../shared-src";
+import { SelectableTextNodeInfo } from "../../shared-src/messages";
 import { getNodeKey, getSelected } from "../pluginDataUtils";
 import { sortNodeByPosition } from "../utils";
 import { iterate } from "./iterate";

--- a/packages/copy-manager/plugin-src/utils.ts
+++ b/packages/copy-manager/plugin-src/utils.ts
@@ -1,5 +1,9 @@
-import { PostToUIMessage, SelectableTextNodeInfo } from "../shared-src";
+import {
+  PostToUIMessage,
+  SelectableTextNodeInfo,
+} from "../shared-src/messages";
 import { PLUGIN_RELAUNCH_KEY_REVIEW_REVISION } from "./pluginDataUtils";
+import { textNodeInfoProcessor } from "./processors/textNodeInfoProcessor";
 
 export type HeadingSettings = {
   h1: number;

--- a/packages/copy-manager/shared-src/index.ts
+++ b/packages/copy-manager/shared-src/index.ts
@@ -1,1 +1,0 @@
-export * from "./messages";

--- a/packages/copy-manager/ui-src/App.tsx
+++ b/packages/copy-manager/ui-src/App.tsx
@@ -1,8 +1,8 @@
 import { SaltProvider } from "@salt-ds/core";
 import React, { useEffect } from "react";
-import { PostToFigmaMessage } from "../shared-src";
-import { useFigmaPluginTheme } from "./components/useFigmaPluginTheme";
+import { PostToFigmaMessage } from "../shared-src/messages";
 import { CornerResizer } from "./components/CornerResizer";
+import { useFigmaPluginTheme } from "./components/useFigmaPluginTheme";
 import { TabsView } from "./view/TabsView";
 
 import "./App.css";

--- a/packages/copy-manager/ui-src/components/NodeKeyInput.tsx
+++ b/packages/copy-manager/ui-src/components/NodeKeyInput.tsx
@@ -1,8 +1,8 @@
-import React, { useCallback, useEffect, useState } from "react";
-import { Input } from "@salt-ds/lab";
-import { SelectableTextNodeInfo } from "../../shared-src";
 import { Button } from "@salt-ds/core";
 import { CloseSmallIcon, WarningIcon } from "@salt-ds/icons";
+import { Input } from "@salt-ds/lab";
+import React from "react";
+import { SelectableTextNodeInfo } from "../../shared-src/messages";
 
 export const NodeKeyInput = ({
   nodeInfo,

--- a/packages/copy-manager/ui-src/view/AdvancedView.tsx
+++ b/packages/copy-manager/ui-src/view/AdvancedView.tsx
@@ -1,22 +1,22 @@
 import {
   Button,
+  Checkbox,
   FlexItem,
   FlexLayout,
   StackLayout,
-  Checkbox,
 } from "@salt-ds/core";
 import { ExportIcon, RefreshIcon, TargetIcon } from "@salt-ds/icons";
 import { Dropdown, FormField, Input } from "@salt-ds/lab";
 import React, { useCallback, useEffect, useState } from "react";
 import {
-  PostToFigmaMessage,
-  PostToUIMessage,
-  SelectableTextNodeInfo,
-} from "../../shared-src";
-import {
   convertToCsvDataUri,
   convertToJsonDataUri,
 } from "../../shared-src/export-utils";
+import {
+  PostToFigmaMessage,
+  PostToUIMessage,
+  SelectableTextNodeInfo,
+} from "../../shared-src/messages";
 import { NodeKeyInput } from "../components/NodeKeyInput";
 import { downloadDataUri } from "../components/utils";
 

--- a/packages/copy-manager/ui-src/view/SimpleView.tsx
+++ b/packages/copy-manager/ui-src/view/SimpleView.tsx
@@ -12,7 +12,7 @@ import {
   DEFAULT_LANG,
   PostToFigmaMessage,
   PostToUIMessage,
-} from "../../shared-src";
+} from "../../shared-src/messages";
 import { downloadDataUri } from "../components/utils";
 
 import "./SimpleView.css";

--- a/vitest/setupFigmaGlobal.ts
+++ b/vitest/setupFigmaGlobal.ts
@@ -1,5 +1,4 @@
-import { populateGlobal } from "vitest/environments";
-import { vi } from "vitest";
+import { vi, beforeAll } from "vitest";
 
 class ComponentNode {
   height: number;
@@ -20,8 +19,9 @@ class ComponentNode {
     this.height = height;
   }
 }
-populateGlobal(global, {
-  figma: {
+
+beforeAll(() => {
+  global.figma = {
     ui: {
       postMessage: vi.fn(),
     },
@@ -32,6 +32,5 @@ populateGlobal(global, {
     },
     createComponent: () => new ComponentNode(),
     createText: vi.fn(),
-  },
-  // Int32Array: vi.fn(),
+  };
 });


### PR DESCRIPTION
Use latest LTS

Error when using node 20 locally as well: 

```
TypeError: Class extends value undefined is not a constructor or null
```

This doesn't seem to be related to local circular dependency like most StackOverflow answer suggested, but with setup files like [here](https://github.com/jpmorganchase/Figma-Plugins-and-Widgets/blob/8d44ad0dfb501917904979060a38e07e2486ac0c/packages/table-generator/vitest.workspace.ts#L19)

It turns out to be the problem of using `import { populateGlobal } from "vitest/environments";`