### PR TITLE
Fix circular dependency in copy-manager

### DIFF
--- a/packages/copy-manager/plugin-src/code.ts
+++ b/packages/copy-manager/plugin-src/code.ts
@@ -1,15 +1,15 @@
 import { ParseResult } from "papaparse";
 import {
+  CSV_HEADER_FIELDS,
   CsvNodeInfo,
   CsvNodeInfoWithLang,
-  CSV_HEADER_FIELDS,
   DEFAULT_LANG,
   PostToFigmaMessage,
   PostToUIMessage,
 } from "../shared-src/messages";
 import {
-  persistInFigma,
   PLUGIN_RELAUNCH_KEY_REVIEW_REVISION,
+  persistInFigma,
   readPersistedData,
   updateNodeKey,
   updateNodeSelected,
@@ -21,10 +21,10 @@ import {
   getNodeInfoMap,
   parseCsvString,
 } from "./processors/csvProcessor";
+import { scanTextNodesInfo } from "./processors/textNodeInfoProcessor";
 import {
   DEFAULT_HEADING_SETTINGS,
   focusNode,
-  scanTextNodesInfo,
   sendTextNodesInfoToUI,
   sortNodeByPosition,
 } from "./utils";

--- a/packages/copy-manager/plugin-src/processors/textNodeInfoProcessor.ts
+++ b/packages/copy-manager/plugin-src/processors/textNodeInfoProcessor.ts
@@ -3,6 +3,24 @@ import { getNodeKey, getSelected } from "../pluginDataUtils";
 import { sortNodeByPosition } from "../utils";
 import { iterate } from "./iterate";
 
+export async function scanTextNodesInfo(autoTrigger: boolean) {
+  if (figma.currentPage.selection.length === 0) {
+    if (!autoTrigger) {
+      figma.notify(`Please select something for scanning`);
+    }
+    return [];
+  }
+
+  const textNodesInfo: SelectableTextNodeInfo[] = [];
+
+  for (const selectedNode of figma.currentPage.selection) {
+    const info = await textNodeInfoProcessor(selectedNode, {});
+    textNodesInfo.push(...info);
+  }
+
+  return textNodesInfo;
+}
+
 export const textNodeInfoTextNodeProcess = (
   node: TextNode,
   settings: any

--- a/packages/copy-manager/plugin-src/utils.ts
+++ b/packages/copy-manager/plugin-src/utils.ts
@@ -1,10 +1,5 @@
 import { PostToUIMessage, SelectableTextNodeInfo } from "../shared-src";
-import {
-  PLUGIN_DATA_KEY_PERSISTED_DATA,
-  PLUGIN_DATA_SHARED_NAMESPACE,
-  PLUGIN_RELAUNCH_KEY_REVIEW_REVISION,
-} from "./pluginDataUtils";
-import { textNodeInfoProcessor } from "./processors/textNodeInfoProcessor";
+import { PLUGIN_RELAUNCH_KEY_REVIEW_REVISION } from "./pluginDataUtils";
 
 export type HeadingSettings = {
   h1: number;
@@ -87,24 +82,6 @@ export const setRelaunchButton = (node: SceneNode) => {
   // Empty string to just show the button
   node.setRelaunchData({ [PLUGIN_RELAUNCH_KEY_REVIEW_REVISION]: "" });
 };
-
-export async function scanTextNodesInfo(autoTrigger: boolean) {
-  if (figma.currentPage.selection.length === 0) {
-    if (!autoTrigger) {
-      figma.notify(`Please select something for scanning`);
-    }
-    return [];
-  }
-
-  const textNodesInfo: SelectableTextNodeInfo[] = [];
-
-  for (const selectedNode of figma.currentPage.selection) {
-    const info = await textNodeInfoProcessor(selectedNode, {});
-    textNodesInfo.push(...info);
-  }
-
-  return textNodesInfo;
-}
 
 export function sendTextNodesInfoToUI(nodesInfo: SelectableTextNodeInfo[]) {
   figma.ui.postMessage({


### PR DESCRIPTION
```
npx madge --circular --extensions ts,tsx ./ --warning        

✖ Found 2 circular dependencies!

1) packages/copy-manager/plugin-src/processors/iterate.ts > packages/copy-manager/plugin-src/utils.ts > packages/copy-manager/plugin-src/processors/textNodeInfoProcessor.ts
2) packages/copy-manager/plugin-src/utils.ts > packages/copy-manager/plugin-src/processors/textNodeInfoProcessor.ts
```